### PR TITLE
Fix/endpoint process

### DIFF
--- a/dharma_transcriptions/config.py
+++ b/dharma_transcriptions/config.py
@@ -5,3 +5,4 @@ load_dotenv()
 
 class Config:
     OUTPUT_FOLDER = os.getenv("OUTPUT_FOLDER")
+    WHISPER_MODEL = os.getenv("WHISPER_MODEL", default='base')

--- a/dharma_transcriptions/config.py
+++ b/dharma_transcriptions/config.py
@@ -4,5 +4,6 @@ from dotenv import load_dotenv
 load_dotenv()
 
 class Config:
-    OUTPUT_FOLDER = os.getenv("OUTPUT_FOLDER")
+    BASE_PATH = os.getenv("BASE_PATH", default=__file__)
+    OUTPUT_FOLDER = os.getenv("OUTPUT_FOLDER", default=os.path.join(__file__, 'output'))
     WHISPER_MODEL = os.getenv("WHISPER_MODEL", default='base')

--- a/dharma_transcriptions/config.py
+++ b/dharma_transcriptions/config.py
@@ -1,0 +1,7 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class Config:
+    OUTPUT_FOLDER = os.getenv("OUTPUT_FOLDER")

--- a/dharma_transcriptions/config.py
+++ b/dharma_transcriptions/config.py
@@ -1,9 +1,13 @@
 import os
+
 from dotenv import load_dotenv
 
 load_dotenv()
 
+
 class Config:
-    BASE_PATH = os.getenv("BASE_PATH", default=__file__)
-    OUTPUT_FOLDER = os.getenv("OUTPUT_FOLDER", default=os.path.join(__file__, 'output'))
-    WHISPER_MODEL = os.getenv("WHISPER_MODEL", default='base')
+    BASE_PATH = os.getenv('BASE_PATH', default=__file__)
+    OUTPUT_FOLDER = os.getenv(
+        'OUTPUT_FOLDER', default=os.path.join(__file__, 'output')
+    )
+    WHISPER_MODEL = os.getenv('WHISPER_MODEL', default='base')

--- a/dharma_transcriptions/routes.py
+++ b/dharma_transcriptions/routes.py
@@ -66,7 +66,7 @@ def register_routes(app):
             )
             print(f'[INFO] Transcrição concluída: {transcript_file}')
             print(f'[INFO] Subtítulos gerados: {subtitle_file}')
-            
+
             print('[INFO] Salvando transcrição no banco de dados...')
             save_transcription_to_db(video_title, transcript_file)
             print('[INFO] Transcrição salva no banco de dados.')

--- a/dharma_transcriptions/routes.py
+++ b/dharma_transcriptions/routes.py
@@ -66,7 +66,7 @@ def register_routes(app):
             )
             print(f'[INFO] Transcrição concluída: {transcript_file}')
             print(f'[INFO] Subtítulos gerados: {subtitle_file}')
-            #TODO - mudar o local e o nome dos arquivos que estão sendo gerados aqui
+            
             print('[INFO] Salvando transcrição no banco de dados...')
             save_transcription_to_db(video_title, transcript_file)
             print('[INFO] Transcrição salva no banco de dados.')

--- a/dharma_transcriptions/routes.py
+++ b/dharma_transcriptions/routes.py
@@ -66,7 +66,7 @@ def register_routes(app):
             )
             print(f'[INFO] Transcrição concluída: {transcript_file}')
             print(f'[INFO] Subtítulos gerados: {subtitle_file}')
-
+            #TODO - mudar o local e o nome dos arquivos que estão sendo gerados aqui
             print('[INFO] Salvando transcrição no banco de dados...')
             save_transcription_to_db(video_title, transcript_file)
             print('[INFO] Transcrição salva no banco de dados.')

--- a/dharma_transcriptions/transcription.py
+++ b/dharma_transcriptions/transcription.py
@@ -1,10 +1,12 @@
 import os
+from dharma_transcriptions.config import Config
 
 from dharma_transcriptions.utils import format_time
 from dharma_transcriptions.whisper_core import load_model
 
 
 def transcribe_audio_and_generate_subtitles(audio_file, video_title):
+    output_folder = Config.OUTPUT_FOLDER
     if not os.path.exists(audio_file):
         raise FileNotFoundError(
             f'Arquivo de áudio não encontrado: {audio_file}'
@@ -18,7 +20,7 @@ def transcribe_audio_and_generate_subtitles(audio_file, video_title):
     result = model.transcribe(audio_file, fp16=False)
     print('[INFO] Transcrição concluída com sucesso.')
 
-    transcript_folder = os.path.join('downloads', video_title)
+    transcript_folder = os.path.join(output_folder, video_title)
     os.makedirs(transcript_folder, exist_ok=True)
 
     transcript_file_path = os.path.join(transcript_folder, 'transcription.txt')

--- a/dharma_transcriptions/transcription.py
+++ b/dharma_transcriptions/transcription.py
@@ -1,6 +1,6 @@
 import os
-from dharma_transcriptions.config import Config
 
+from dharma_transcriptions.config import Config
 from dharma_transcriptions.utils import format_time
 from dharma_transcriptions.whisper_core import load_model
 

--- a/dharma_transcriptions/whisper_core.py
+++ b/dharma_transcriptions/whisper_core.py
@@ -7,32 +7,43 @@ import whisper
 
 def load_model(fine_tuned=False):
     model = whisper.load_model(Config.WHISPER_MODEL)
+    BASE_PATH = Config.BASE_PATH
 
     if fine_tuned:
         """
     Carrega o modelo Whisper treinado (fine-tuned).
     """
-        TRAINED_MODEL_PATH = os.path.join(
+        TRAINED_MODEL_PATH = os.path.join(BASE_PATH,
             'trained_models', 'whisper_finetuned.pt'
         )
 
-        if not os.path.exists(TRAINED_MODEL_PATH):
-            raise FileNotFoundError(
-                f'Modelo treinado não encontrado: {TRAINED_MODEL_PATH}'
-            )
+        try: 
+            print('[INFO] Carregando modelo treinado...')
+            model.load_state_dict(torch.load(TRAINED_MODEL_PATH))
+            print('[INFO] Modelo treinado carregado com sucesso.')
 
-        print('[INFO] Carregando modelo treinado...')
-        model.load_state_dict(torch.load(TRAINED_MODEL_PATH))
-        print('[INFO] Modelo treinado carregado com sucesso.')
+        except FileNotFoundError:
+            print (
+                f'[WARNING] Modelo treinado não encontrado em: {TRAINED_MODEL_PATH}. Usando modelo padrão'
+            )
+            turn_required_grads(model)
+
+        
         return model
     else:
+        turn_required_grads(model)
+        
+def turn_required_grads(model):
         """
-    Carrega o modelo base do Whisper e habilita o cálculo de gradientes.
+    Retorna o modelo base do Whisper com o cálculo de gradientes habilitado.
     """
-        print('[INFO] Carregando o modelo base Whisper...')
+        print(f'[INFO] Carregando o modelo Whisper {Config.WHISPER_MODEL} ...')
         # Habilitar cálculo de gradientes para ajuste fino
         for param in model.parameters():
             param.requires_grad = True
 
-        print('[INFO] Modelo base Whisper carregado com sucesso.')
+        print(f'[INFO] Modelo Whisper {Config.WHISPER_MODEL} carregado com sucesso.')
         return model
+
+if __name__=='__main__':
+     load_model(True)

--- a/dharma_transcriptions/whisper_core.py
+++ b/dharma_transcriptions/whisper_core.py
@@ -1,11 +1,12 @@
 import os
+from dharma_transcriptions.config import Config
 
 import torch
 import whisper
 
 
 def load_model(fine_tuned=False):
-    model = whisper.load_model('base')
+    model = whisper.load_model(Config.WHISPER_MODEL)
 
     if fine_tuned:
         """

--- a/dharma_transcriptions/whisper_core.py
+++ b/dharma_transcriptions/whisper_core.py
@@ -1,8 +1,9 @@
 import os
-from dharma_transcriptions.config import Config
 
 import torch
 import whisper
+
+from dharma_transcriptions.config import Config
 
 
 def load_model(fine_tuned=False):
@@ -13,39 +14,43 @@ def load_model(fine_tuned=False):
         """
     Carrega o modelo Whisper treinado (fine-tuned).
     """
-        TRAINED_MODEL_PATH = os.path.join(BASE_PATH,
-            'trained_models', 'whisper_finetuned.pt'
+        TRAINED_MODEL_PATH = os.path.join(
+            BASE_PATH, 'trained_models', 'whisper_finetuned.pt'
         )
 
-        try: 
+        try:
             print('[INFO] Carregando modelo treinado...')
             model.load_state_dict(torch.load(TRAINED_MODEL_PATH))
             print('[INFO] Modelo treinado carregado com sucesso.')
             return model
-        
+
         except FileNotFoundError:
-            print (
-                f'[WARNING] Modelo treinado não encontrado em: {TRAINED_MODEL_PATH}. Usando modelo padrão'
+            print(
+                '[WARNING] Modelo treinado não encontrado em:',
+                '{TRAINED_MODEL_PATH}. Usando modelo padrão.',
             )
             return turn_required_grads(model)
 
-              
     else:
         return turn_required_grads(model)
-        
+
+
 def turn_required_grads(model):
-        """
+    """
     Retorna o modelo base do Whisper com o cálculo de gradientes habilitado.
     """
-        print(f'[INFO] Carregando o modelo Whisper {Config.WHISPER_MODEL} ...')
-        # Habilitar cálculo de gradientes para ajuste fino
-        #TODO: testar se ele realmente está alterando esses parametros pra True
-        # e verificar o que significa isso. (Diego)
-        for param in model.parameters():
-            param.requires_grad = True
+    print(f'[INFO] Carregando o modelo Whisper {Config.WHISPER_MODEL} ...')
+    # Habilitar cálculo de gradientes para ajuste fino
+    # TODO: testar se ele realmente está alterando esses parametros pra True
+    # e verificar o que significa isso. (Diego)
+    for param in model.parameters():
+        param.requires_grad = True
 
-        print(f'[INFO] Modelo Whisper {Config.WHISPER_MODEL} carregado com sucesso.')
-        return model
+    print(
+        f'[INFO] Modelo Whisper {Config.WHISPER_MODEL} carregado com sucesso.'
+    )
+    return model
 
-if __name__=='__main__':
-     model = load_model(True)
+
+if __name__ == '__main__':
+    model = load_model(True)

--- a/dharma_transcriptions/whisper_core.py
+++ b/dharma_transcriptions/whisper_core.py
@@ -21,17 +21,17 @@ def load_model(fine_tuned=False):
             print('[INFO] Carregando modelo treinado...')
             model.load_state_dict(torch.load(TRAINED_MODEL_PATH))
             print('[INFO] Modelo treinado carregado com sucesso.')
-
+            return model
+        
         except FileNotFoundError:
             print (
                 f'[WARNING] Modelo treinado não encontrado em: {TRAINED_MODEL_PATH}. Usando modelo padrão'
             )
-            turn_required_grads(model)
+            return turn_required_grads(model)
 
-        
-        return model
+              
     else:
-        turn_required_grads(model)
+        return turn_required_grads(model)
         
 def turn_required_grads(model):
         """
@@ -39,6 +39,8 @@ def turn_required_grads(model):
     """
         print(f'[INFO] Carregando o modelo Whisper {Config.WHISPER_MODEL} ...')
         # Habilitar cálculo de gradientes para ajuste fino
+        #TODO: testar se ele realmente está alterando esses parametros pra True
+        # e verificar o que significa isso. (Diego)
         for param in model.parameters():
             param.requires_grad = True
 
@@ -46,4 +48,4 @@ def turn_required_grads(model):
         return model
 
 if __name__=='__main__':
-     load_model(True)
+     model = load_model(True)

--- a/dharma_transcriptions/youtube.py
+++ b/dharma_transcriptions/youtube.py
@@ -1,8 +1,8 @@
 import os
-from dharma_transcriptions.config import Config
 
 import yt_dlp
 
+from dharma_transcriptions.config import Config
 from dharma_transcriptions.utils import sanitize_filename
 
 
@@ -14,7 +14,9 @@ def download_audio(youtube_url):
 
     ydl_opts = {
         'format': 'bestaudio/best',
-        'outtmpl': os.path.join(output_folder,sanitize_filename('%(title)s'),'%(title)s.%(ext)s'),
+        'outtmpl': os.path.join(
+            output_folder, sanitize_filename('%(title)s'), '%(title)s.%(ext)s'
+        ),
         'postprocessors': [
             {
                 'key': 'FFmpegExtractAudio',
@@ -27,20 +29,24 @@ def download_audio(youtube_url):
 
     try:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            info_dict = ydl.extract_info(youtube_url, download=True) #TODO: tem uma opção -o no yt-dlp pra definir template do download
+            info_dict = ydl.extract_info(
+                youtube_url, download=True
+            )  # TODO: tem uma opção -o no yt-dlp
+            # pra definir template do download
 
             raw_title = info_dict.get('title', 'arquivo_desconhecido')
             sanitized_title = sanitize_filename(raw_title)
-            output_folder = os.path.join(output_folder,sanitized_title)
-            audio_file = os.path.join(output_folder,f'{sanitized_title}.mp3')
-
+            output_folder = os.path.join(output_folder, sanitized_title)
+            audio_file = os.path.join(output_folder, f'{sanitized_title}.mp3')
 
             # Renomeie o arquivo após o download e sanitização
             downloaded_file = ydl.prepare_filename(info_dict)
             downloaded_file = os.path.splitext(downloaded_file)[0] + '.mp3'
-            # import pdb; pdb.set_trace()
 
             os.rename(downloaded_file, audio_file)
-            return audio_file, sanitized_title  # Retorna apenas o caminho do arquivo
+            return (
+                audio_file,
+                sanitized_title,
+            )  # Retorna apenas o caminho do arquivo
     except Exception as e:
         raise Exception(f'Erro ao baixar ou converter áudio: {str(e)}') from e

--- a/dharma_transcriptions/youtube.py
+++ b/dharma_transcriptions/youtube.py
@@ -14,7 +14,7 @@ def download_audio(youtube_url):
 
     ydl_opts = {
         'format': 'bestaudio/best',
-        'outtmpl': os.path.join(output_folder, '%(title)s.%(ext)s'),
+        'outtmpl': os.path.join(output_folder,sanitize_filename('%(title)s'),'%(title)s.%(ext)s'),
         'postprocessors': [
             {
                 'key': 'FFmpegExtractAudio',
@@ -27,17 +27,20 @@ def download_audio(youtube_url):
 
     try:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            info_dict = ydl.extract_info(youtube_url, download=True)
+            info_dict = ydl.extract_info(youtube_url, download=True) #TODO: tem uma opção -o no yt-dlp pra definir template do download
+
             raw_title = info_dict.get('title', 'arquivo_desconhecido')
             sanitized_title = sanitize_filename(raw_title)
-            audio_file = os.path.join(output_folder, f'{sanitized_title}.mp3') #TODO aqui que ele grava na pasta /downloads, mudar pra pasta do sistema
+            output_folder = os.path.join(output_folder,sanitized_title)
+            audio_file = os.path.join(output_folder,f'{sanitized_title}.mp3')
+
 
             # Renomeie o arquivo após o download e sanitização
-            downloaded_file = ydl.prepare_filename(info_dict).replace(
-                '.webm', '.mp3'
-            )
-            os.rename(downloaded_file, audio_file)
+            downloaded_file = ydl.prepare_filename(info_dict)
+            downloaded_file = os.path.splitext(downloaded_file)[0] + '.mp3'
+            # import pdb; pdb.set_trace()
 
+            os.rename(downloaded_file, audio_file)
             return audio_file, sanitized_title  # Retorna apenas o caminho do arquivo
     except Exception as e:
         raise Exception(f'Erro ao baixar ou converter áudio: {str(e)}') from e

--- a/dharma_transcriptions/youtube.py
+++ b/dharma_transcriptions/youtube.py
@@ -29,7 +29,7 @@ def download_audio(youtube_url):
             info_dict = ydl.extract_info(youtube_url, download=True)
             raw_title = info_dict.get('title', 'arquivo_desconhecido')
             sanitized_title = sanitize_filename(raw_title)
-            audio_file = os.path.join(output_folder, f'{sanitized_title}.mp3')
+            audio_file = os.path.join(output_folder, f'{sanitized_title}.mp3') #TODO aqui que ele grava na pasta /downloads, mudar pra pasta do sistema
 
             # Renomeie o arquivo após o download e sanitização
             downloaded_file = ydl.prepare_filename(info_dict).replace(
@@ -37,6 +37,6 @@ def download_audio(youtube_url):
             )
             os.rename(downloaded_file, audio_file)
 
-            return audio_file  # Retorna apenas o caminho do arquivo
+            return audio_file, sanitized_title  # Retorna apenas o caminho do arquivo
     except Exception as e:
         raise Exception(f'Erro ao baixar ou converter áudio: {str(e)}') from e

--- a/dharma_transcriptions/youtube.py
+++ b/dharma_transcriptions/youtube.py
@@ -1,4 +1,5 @@
 import os
+from dharma_transcriptions.config import Config
 
 import yt_dlp
 
@@ -6,7 +7,7 @@ from dharma_transcriptions.utils import sanitize_filename
 
 
 def download_audio(youtube_url):
-    output_folder = 'downloads'
+    output_folder = Config.OUTPUT_FOLDER
     os.makedirs(output_folder, exist_ok=True)
 
     ffmpeg_location = os.environ.get('FFMPEG_LOCATION')

--- a/poetry.lock
+++ b/poetry.lock
@@ -1342,26 +1342,26 @@ six = "*"
 
 [[package]]
 name = "yt-dlp"
-version = "2024.12.23"
+version = "2025.1.12"
 description = "A feature-rich command-line audio/video downloader"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "yt_dlp-2024.12.23-py3-none-any.whl", hash = "sha256:2fc08a5221a0379628ac4e7324c6c69a95b9fdfa7a7ca3187444b3b7451e38be"},
-    {file = "yt_dlp-2024.12.23.tar.gz", hash = "sha256:ac0e72b5a9017ba104b4258546201a7cedc38e8bd20727e0c63b77c829b425e9"},
+    {file = "yt_dlp-2025.1.12-py3-none-any.whl", hash = "sha256:f7ea19afb64f8e457a1b9598ddb67f8deaa313bf1d57abd5612db9272ab10795"},
+    {file = "yt_dlp-2025.1.12.tar.gz", hash = "sha256:8e7e246e2a5a2cff0a9c13db46844a37a547680702012058c94ec18fce0ca25a"},
 ]
 
 [package.extras]
 build = ["build", "hatchling", "pip", "setuptools (>=71.0.2)", "wheel"]
 curl-cffi = ["curl-cffi (==0.5.10)", "curl-cffi (>=0.5.10,!=0.6.*,<0.7.2)"]
 default = ["brotli", "brotlicffi", "certifi", "mutagen", "pycryptodomex", "requests (>=2.32.2,<3)", "urllib3 (>=1.26.17,<3)", "websockets (>=13.0)"]
-dev = ["autopep8 (>=2.0,<3.0)", "pre-commit", "pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)", "ruff (>=0.8.0,<0.9.0)"]
+dev = ["autopep8 (>=2.0,<3.0)", "pre-commit", "pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)", "ruff (>=0.9.0,<0.10.0)"]
 pyinstaller = ["pyinstaller (>=6.11.1)"]
 secretstorage = ["cffi", "secretstorage"]
-static-analysis = ["autopep8 (>=2.0,<3.0)", "ruff (>=0.8.0,<0.9.0)"]
+static-analysis = ["autopep8 (>=2.0,<3.0)", "ruff (>=0.9.0,<0.10.0)"]
 test = ["pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.7"
-content-hash = "f34e01779f8019874e4d28c989ba8a2e7744c015dd3339efaabda9908fe401e4"
+content-hash = "728a221602bb83f2ab5446eec01b98923942a24d7ae0afe46c0d73654761bd8a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "3.12.7"
 flask = "^3.1.0"
-yt-dlp = "^2024.12.6"
+yt-dlp = "^2025.01.12"
 torch = "^2.5.1"
 whisper = "^1.1.10"
 llvmlite = "^0.43.0"

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
         <a id="subtitle-link" href="#" download style="display: block;">Baixar Legendas</a>
     </div>
 </div>
-{% endblock %}
+
 
 <script>
     function processVideo(event) {
@@ -54,3 +54,4 @@
     }
 </script>
 
+{% endblock %}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,12 @@ def test_sanitize_filename():
     assert sanitize_filename('file:name') == 'file_name'
     assert sanitize_filename('file\\path') == 'file_path'
     assert sanitize_filename('file|name') == 'file_name'
-    assert sanitize_filename('Alan Wallace ｜ Conselho para quem deseja superar as aflições') == 'Alan Wallace _ Conselho para quem deseja superar as aflições'
+    assert (
+        sanitize_filename(
+            'Alan Wallace ｜ Conselho para quem deseja superar as aflições'
+        )
+        == 'Alan Wallace _ Conselho para quem deseja superar as aflições'
+    )
 
     # Test with no invalid characters
     assert sanitize_filename('valid_filename') == 'valid_filename'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ def test_sanitize_filename():
     assert sanitize_filename('file:name') == 'file_name'
     assert sanitize_filename('file\\path') == 'file_path'
     assert sanitize_filename('file|name') == 'file_name'
+    assert sanitize_filename('Alan Wallace ｜ Conselho para quem deseja superar as aflições') == 'Alan Wallace _ Conselho para quem deseja superar as aflições'
 
     # Test with no invalid characters
     assert sanitize_filename('valid_filename') == 'valid_filename'


### PR DESCRIPTION
Fix:

- Now the front end (index.html) can call the process endpoint using the POST method.
- I updated yt-dlp to the version released this week.
- The download_audio() method in the /process route was breaking because it expected two variables but was returning only one.
- Now the whisper_core.load_model() won't break if `fine_tuned` is True but there is no fine tuned model, it will load the default model and give a warning instead

Added:
- Now you configure output and model files path using the Config class on cofig.py
- You can use an .env file to store those configurations

Known bugs:
- The 'sanitize_filename' has an erratic behaviour for some character (I wrote a test that detects this behaviour for | character)
- The training_manager doesn't train anything and is redundant with whisper_training.